### PR TITLE
Add interactive card play and trick stack display

### DIFF
--- a/game.py
+++ b/game.py
@@ -99,9 +99,26 @@ class Game:
         return "All bids are in.", False  # Indicate bidding complete
 
     def play_card(self, player_name, card):
+        """Play ``card`` for ``player_name``.
+
+        Parameters
+        ----------
+        player_name : str
+            Name of the player.
+        card : Card or str
+            ``Card`` instance or string representation of the card.
+        """
+
         player = next((p for p in self.players if p.name == player_name), None)
         if not player:
             return f"Player {player_name} not found."
+
+        # Allow card to be provided as a string (e.g. "2_of_Hearts")
+        if isinstance(card, str):
+            card_obj = next((c for c in player.hand if str(c) == card), None)
+            if not card_obj:
+                return f"{player_name} cannot play {card}."
+            card = card_obj
 
         if card not in player.hand:
             return f"{player_name} cannot play {card}."
@@ -120,6 +137,17 @@ class Game:
             self.resolve_trick()
 
         return None
+
+    def autoplay_until_player(self):
+        """Have AI players play until it is the user's turn or the trick ends."""
+        while len(self.trick_cards) < self.num_players:
+            idx = (self.leader_index + len(self.trick_cards)) % self.num_players
+            player = self.players[idx]
+            if player.name == "You":
+                break
+            playable = self.get_playable_cards(player)
+            if playable:
+                self.play_card(player.name, playable[0])
 
     def get_playable_cards(self, player):
         if not self.trick_cards:

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,6 +51,10 @@
         await post('/bid', {bid: bid});
     }
 
+    function playCard(card){
+        post('/play', {card: card});
+    }
+
     function renderState(data){
         document.getElementById('round-info').textContent = 'Round: ' + data.round;
         const table = document.getElementById('table');
@@ -91,6 +95,10 @@
                         img.src = c;
                         img.style.width = '40px';
                         img.style.height = '60px';
+                        img.onclick = ()=>{
+                            const id = c.split('/').pop().replace('.png','');
+                            playCard(id);
+                        };
                         cardDiv.appendChild(img);
                     });
                 } else {
@@ -110,7 +118,9 @@
                     img.style.width = '20px';
                     img.style.height = '30px';
                     img.style.position = 'absolute';
-                    img.style.left = (i*5)+'px';
+                    img.style.left = (Math.floor(i/2)*5)+'px';
+                    img.style.top = (i%2)*8+'px';
+                    img.style.transform = i%2 ? 'rotate(90deg)' : 'rotate(0deg)';
                     won.appendChild(img);
                 });
             }
@@ -151,6 +161,7 @@
     }
 
     update();
+    setInterval(update, 1000);
     </script>
 </body>
 </html>

--- a/website.py
+++ b/website.py
@@ -17,6 +17,7 @@ def start():
     global game
     game = Game(num_players=players, num_rounds=rounds)
     game.start_round()
+    game.autoplay_until_player()
     return jsonify({'status': 'started'})
 
 @app.route('/reset', methods=['POST'])
@@ -31,8 +32,18 @@ def bid():
     bid_value = int(data.get('bid', 0))
     game.receive_bid('You', bid_value)
     game.manage_turns()
-    game.autoplay_trick()
+    game.autoplay_until_player()
     return jsonify({'status': 'bid received'})
+
+@app.route('/play', methods=['POST'])
+def play():
+    data = request.get_json()
+    card = data.get('card')
+    err = game.play_card('You', card)
+    if err:
+        return jsonify({'error': err}), 400
+    game.autoplay_until_player()
+    return jsonify({'status': 'card played'})
 
 @app.route('/state')
 def state():


### PR DESCRIPTION
## Summary
- allow card selection for player turns
- add new `/play` endpoint for playing cards
- automatically progress AI turns until the next player action is required
- display won piles in an alternating `-| -|` pattern
- periodically refresh the game state

## Testing
- `python -m py_compile website.py game.py player.py deck.py card.py image_loader.py app.py`